### PR TITLE
feat: expand chat completions to support tool calls & apply patch

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "libc",
  "mcp-types",
  "mime_guess",
+ "once_cell",
  "openssl-sys",
  "patch",
  "path-absolutize",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "tracing",
  "tree-sitter",
  "tree-sitter-bash",
+ "url",
  "uuid",
  "wiremock",
 ]

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -47,6 +47,7 @@ tree-sitter = "0.25.3"
 tree-sitter-bash = "0.23.3"
 uuid = { version = "1", features = ["serde", "v4"] }
 once_cell = "1"
+url = { version = "2.5.4", features = ["serde"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.172"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -46,6 +46,7 @@ tracing = { version = "0.1.41", features = ["log"] }
 tree-sitter = "0.25.3"
 tree-sitter-bash = "0.23.3"
 uuid = { version = "1", features = ["serde", "v4"] }
+once_cell = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.172"

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -38,29 +38,128 @@ pub(crate) async fn stream_chat_completions(
 ) -> Result<ResponseStream> {
     // Build messages array
     let mut messages = Vec::<serde_json::Value>::new();
+    let mut full_instructions = prompt.get_full_instructions().into_owned();
 
-    let full_instructions = prompt.get_full_instructions();
+    // Embed previous_response_id so the model can reference the prior turn.
+    if let Some(prev_id) = &prompt.prev_id {
+        full_instructions.push_str(&format!(
+            "\n\n[METADATA] previous_response_id = {}",
+            prev_id
+        ));
+    }
     messages.push(json!({"role": "system", "content": full_instructions}));
 
     for item in &prompt.input {
-        if let ResponseItem::Message { role, content } = item {
-            let mut text = String::new();
-            for c in content {
-                match c {
-                    ContentItem::InputText { text: t } | ContentItem::OutputText { text: t } => {
-                        text.push_str(t);
+        match item {
+            ResponseItem::Message { role, content } => {
+                // Aggregate the textual parts into a single string. We ignore
+                // images and other modalities for now; those are handled
+                // separately.
+                let mut text = String::new();
+                for c in content {
+                    match c {
+                        ContentItem::InputText { text: t }
+                        | ContentItem::OutputText { text: t } => {
+                            text.push_str(t);
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
+                messages.push(json!({"role": role, "content": text}));
             }
-            messages.push(json!({"role": role, "content": text}));
+            // Surface prior tool call results so the model can take them into
+            // account. 
+            ResponseItem::FunctionCallOutput { call_id, output } => {
+                messages.push(json!({
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": output.content,
+                }));
+            }
+            // Retain the *assistant-initiated* tool invocation in the history so the
+            // following `tool` message is considered valid by the Chat Completions
+            // protocol validator. Omitting it causes the 400:
+            //   "messages with role 'tool' must be a response to a preceding message with 'tool_calls'".
+            ResponseItem::FunctionCall { name, arguments, call_id } => {
+                messages.push(json!({
+                    "role": "assistant",
+                    "content": serde_json::Value::Null,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": arguments,
+                        }
+                    }]
+                }));
+            }
+            _ => {}
         }
     }
 
+    // Minimal "shell" tool identical to what the Responses API advertises but
+    // converted to the Chat-Completions schema.
+    let mut tools_json = Vec::new();
+
+    // Built-in shell function (always present so the model can decide to use
+    // it – the CLI will execute it locally when received via
+    // `ResponseItem::FunctionCall`).
+    tools_json.push(json!({
+        "type": "function",
+        "function": {
+            "name": "shell",
+            "description": "Runs a shell command, and returns its output.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    },
+                    "workdir": { "type": "string" },
+                    "timeout": { "type": "number" }
+                },
+                "required": ["command"],
+                "additionalProperties": false
+            }
+        }
+    }));
+
+    // Extra tools coming from external MCP servers (if any) – they are
+    // already valid JSON Schemas so we can wrap them inside the Chat tool
+    // envelope without further transformation.
+    for (name, tool) in &prompt.extra_tools {
+        let mut desc = "External tool".to_string();
+        let mut params = json!({ "type": "object" });
+
+        if let Ok(val) = serde_json::to_value(tool) {
+            // Best-effort extraction; ignore errors and fall back to defaults.
+            if let Some(d) = val.get("description").and_then(|v| v.as_str()) {
+                desc = d.to_string();
+            }
+            if let Some(p) = val.get("parameters") {
+                params = p.clone();
+            }
+        }
+
+        tools_json.push(json!({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": desc,
+                "parameters": params
+            }
+        }));
+    }
+
+    // Final request payload
     let payload = json!({
         "model": model,
         "messages": messages,
-        "stream": true
+        "stream": true,
+        "tools": tools_json,
+        "tool_choice": "auto"
     });
 
     let url = provider.base_url.clone().append_path("/chat/completions")?.to_string();
@@ -134,6 +233,20 @@ where
 
     let idle_timeout = *OPENAI_STREAM_IDLE_TIMEOUT_MS;
 
+    // Accumulators used when the assistant returns a streaming function/tool
+    // call.  The OpenAI Chat Completions SSE format may emit `function_call`
+    // or `tool_calls` deltas with the `name` and `arguments` fields spread
+    // across multiple chunks.  We buffer the pieces here until the model
+    // signals completion via `finish_reason`, at which point we forward a
+    // fully-assembled `ResponseItem::FunctionCall` to higher layers.
+    let mut cur_call_name = String::new();
+    let mut cur_call_args = String::new();
+    let mut cur_call_id = String::new();
+
+    // Response id propagated through the Completed event so higher layers can
+    // chain turns (parity with the Responses API).
+    let mut response_id: Option<String> = None;
+
     loop {
         let sse = match timeout(idle_timeout, stream.next()).await {
             Ok(Some(Ok(ev))) => ev,
@@ -145,7 +258,7 @@ where
                 // Stream closed gracefully – emit Completed with dummy id.
                 let _ = tx_event
                     .send(Ok(ResponseEvent::Completed {
-                        response_id: String::new(),
+                        response_id: response_id.clone().unwrap_or_default(),
                     }))
                     .await;
                 return;
@@ -162,7 +275,7 @@ where
         if sse.data.trim() == "[DONE]" {
             let _ = tx_event
                 .send(Ok(ResponseEvent::Completed {
-                    response_id: String::new(),
+                    response_id: response_id.clone().unwrap_or_default(),
                 }))
                 .await;
             return;
@@ -171,17 +284,33 @@ where
         // Parse JSON chunk
         let chunk: serde_json::Value = match serde_json::from_str(&sse.data) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(e) => {
+                debug!("Failed to parse chat SSE JSON: {e}; raw data: {}", &sse.data);
+                continue;
+            }
         };
 
-        let content_opt = chunk
-            .get("choices")
-            .and_then(|c| c.get(0))
-            .and_then(|c| c.get("delta"))
-            .and_then(|d| d.get("content"))
-            .and_then(|c| c.as_str());
 
-        if let Some(content) = content_opt {
+        // Cache the stream-wide id (only first occurrence needed).
+        if response_id.is_none() {
+            if let Some(id_val) = chunk.get("id").and_then(|v| v.as_str()) {
+                response_id = Some(id_val.to_string());
+            }
+        }
+
+        trace!("chat-sse delta: {}", chunk);
+
+        let choice = match chunk.get("choices").and_then(|c| c.get(0)) {
+            Some(c) => c,
+            None => continue,
+        };
+        let delta = choice.get("delta");
+
+        // Assistant text tokens
+        if let Some(content) = delta
+            .and_then(|d| d.get("content"))
+            .and_then(|c| c.as_str())
+        {
             let item = ResponseItem::Message {
                 role: "assistant".to_string(),
                 content: vec![ContentItem::OutputText {
@@ -190,6 +319,80 @@ where
             };
 
             let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
+        }
+
+        // Legacy single function_call representation
+        if let Some(fc) = delta.and_then(|d| d.get("function_call")) {
+            let name_opt = fc.get("name").and_then(|v| v.as_str());
+            let args_opt = fc.get("arguments").and_then(|v| v.as_str());
+            if let Some(name) = name_opt {
+                if cur_call_name.is_empty() {
+                    cur_call_name.push_str(name);
+                }
+            }
+                if let Some(args) = args_opt {
+                    cur_call_args.push_str(args);
+                }
+        }
+
+        // New tool_calls representation (array) – we only track the first
+        //    entry for now which is sufficient for serial, single calls.
+        if let Some(tool_calls) = delta.and_then(|d| d.get("tool_calls")).and_then(|v| v.as_array()) {
+            if let Some(first) = tool_calls.first() {
+                let id_opt = first.get("id").and_then(|v| v.as_str());
+                let func_obj = first.get("function");
+                let name_opt = func_obj.and_then(|f| f.get("name").and_then(|v| v.as_str()));
+                let args_opt = func_obj.and_then(|f| f.get("arguments").and_then(|v| v.as_str()));
+
+                if let Some(id) = id_opt {
+                    if cur_call_id.is_empty() {
+                        cur_call_id.push_str(id);
+                    }
+                }
+                if let Some(name) = name_opt {
+                    if cur_call_name.is_empty() {
+                        cur_call_name.push_str(name);
+                    }
+                }
+                if let Some(args) = args_opt {
+                    cur_call_args.push_str(args);
+                }
+            }
+        }
+
+        // On finish_reason emit the accumulated function call.
+        if let Some(_reason) = choice
+            .get("finish_reason")
+            .and_then(|v| v.as_str())
+        {
+            // Any non-null finish_reason marks the end of the streaming block
+            // for this choice. For the legacy single `function_call` format
+            // OpenAI uses `"stop"`; for the newer array-based tool-calling
+            // it is `"tool_calls"`. We flush *whenever* we have an
+            // accumulated call and the model says it is done.
+            if !cur_call_name.is_empty() {
+                if !cur_call_name.is_empty() {
+                    // Replace any literal newlines that slipped through the
+                    // streaming decoder with the escaped variant so the
+                    // resulting JSON remains valid when downstream deserializes
+                    // it via `serde_json::from_str()`.
+                    let sanitized_args = cur_call_args
+                        .replace('\n', "\\n")
+                        .replace('\r', "\\r");
+
+                    let item = ResponseItem::FunctionCall {
+                        name: cur_call_name.clone(),
+                        arguments: sanitized_args,
+                        call_id: cur_call_id.clone(),
+                    };
+                    let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
+                }
+
+                // Clear accumulators for next call
+                cur_call_name.clear();
+                cur_call_args.clear();
+                cur_call_id.clear();
+            }
         }
     }
 }
@@ -236,7 +439,11 @@ where
                 Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
                 Poll::Ready(Some(Ok(ResponseEvent::OutputItemDone(item)))) => {
-                    // Accumulate *assistant* text but do not emit yet.
+                    // Accumulate *assistant* text but do not emit yet.  All
+                    // other item types (function calls, tool calls, …) are
+                    // forwarded immediately so higher layers receive them in
+                    // real-time.
+
                     if let crate::models::ResponseItem::Message { role, content } = &item {
                         if role == "assistant" {
                             if let Some(text) = content.iter().find_map(|c| match c {
@@ -245,11 +452,16 @@ where
                             }) {
                                 this.cumulative.push_str(text);
                             }
+
+                            // Swallow partial assistant delta; keep polling
+                            // until Completed so we can emit a *single*
+                            // aggregated message at the end of the turn.
+                            continue;
                         }
                     }
 
-                    // Swallow partial event; keep polling.
-                    continue;
+                    // Non-assistant items are forwarded immediately.
+                    return Poll::Ready(Some(Ok(ResponseEvent::OutputItemDone(item))));
                 }
                 Poll::Ready(Some(Ok(ResponseEvent::Completed { response_id }))) => {
                     if !this.cumulative.is_empty() {

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -26,6 +26,7 @@ use crate::flags::OPENAI_STREAM_IDLE_TIMEOUT_MS;
 use crate::models::ContentItem;
 use crate::models::ResponseItem;
 use crate::util::backoff;
+use crate::util::UrlExt;
 
 /// Implementation for the classic Chat Completions API. This is intentionally
 /// minimal: we only stream back plain assistant text.
@@ -62,10 +63,9 @@ pub(crate) async fn stream_chat_completions(
         "stream": true
     });
 
-    let base_url = provider.base_url.trim_end_matches('/');
-    let url = format!("{}/chat/completions", base_url);
+    let url = provider.base_url.clone().append_path("/chat/completions")?.to_string();
 
-    debug!(url, "POST (chat)");
+    debug!("{} POST (chat)", &url);
     trace!("request payload: {}", payload);
 
     let api_key = provider.api_key()?;

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -37,6 +37,7 @@ use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::WireApi;
 use crate::models::ResponseItem;
 use crate::util::backoff;
+use crate::util::UrlExt;
 
 /// When serialized as JSON, this produces a valid "Tool" in the OpenAI
 /// Responses API.
@@ -198,10 +199,8 @@ impl ModelClient {
             stream: true,
         };
 
-        let base_url = self.provider.base_url.clone();
-        let base_url = base_url.trim_end_matches('/');
-        let url = format!("{}/responses", base_url);
-        debug!(url, "POST");
+        let url = self.provider.base_url.clone().append_path("/responses")?.to_string();
+        debug!("{} POST", url);
         trace!("request payload: {}", serde_json::to_string(&payload)?);
 
         let mut attempt = 0;

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -679,7 +679,7 @@ disable_response_storage = true
 
         let openai_chat_completions_provider = ModelProviderInfo {
             name: "OpenAI using Chat Completions".to_string(),
-            base_url: "https://api.openai.com/v1".to_string(),
+            base_url: url::Url::parse("https://api.openai.com/v1").unwrap(),
             env_key: Some("OPENAI_API_KEY".to_string()),
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -294,7 +294,7 @@ impl Config {
         let codex_home = find_codex_home()?;
 
         let cfg: ConfigToml = ConfigToml::load_from_toml(&codex_home)?;
-        tracing::warn!("Config parsed from config.toml: {cfg:?}");
+        // tracing::warn!("Config parsed from config.toml: {cfg:?}");
 
         Self::load_from_base_config_with_overrides(cfg, overrides, codex_home)
     }

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -99,6 +99,9 @@ pub enum CodexErr {
 
     #[error("{0}")]
     EnvVar(EnvVarError),
+
+    #[error(transparent)]
+    InternalError(#[from] anyhow::Error),
 }
 
 #[derive(Debug)]

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -29,7 +29,7 @@ use crate::protocol::SandboxPolicy;
 const MAX_STREAM_OUTPUT: usize = 10 * 1024;
 const MAX_STREAM_OUTPUT_LINES: usize = 256;
 
-const DEFAULT_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_TIMEOUT_MS: u64 = 300_000; // 5 minutes in milliseconds
 
 // Hardcode these since it does not seem worth including the libc crate just
 // for these.

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::env::VarError;
+use url::Url;
 
 use crate::error::EnvVarError;
 
@@ -34,7 +35,7 @@ pub struct ModelProviderInfo {
     /// Friendly display name.
     pub name: String,
     /// Base URL for the provider's OpenAI-compatible API.
-    pub base_url: String,
+    pub base_url: Url,
     /// Environment variable that stores the user's API key for this provider.
     pub env_key: Option<String>,
 
@@ -80,7 +81,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "openai",
             P {
                 name: "OpenAI".into(),
-                base_url: "https://api.openai.com/v1".into(),
+                base_url: Url::parse("https://api.openai.com/v1").unwrap(),
                 env_key: Some("OPENAI_API_KEY".into()),
                 env_key_instructions: Some("Create an API key (https://platform.openai.com) and export it as an environment variable.".into()),
                 wire_api: WireApi::Responses,
@@ -90,7 +91,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "openrouter",
             P {
                 name: "OpenRouter".into(),
-                base_url: "https://openrouter.ai/api/v1".into(),
+                base_url: Url::parse("https://openrouter.ai/api/v1").unwrap(),
                 env_key: Some("OPENROUTER_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -100,7 +101,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "gemini",
             P {
                 name: "Gemini".into(),
-                base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
+                base_url: Url::parse("https://generativelanguage.googleapis.com/v1beta/openai").unwrap(),
                 env_key: Some("GEMINI_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -110,7 +111,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "ollama",
             P {
                 name: "Ollama".into(),
-                base_url: "http://localhost:11434/v1".into(),
+                base_url: Url::parse("http://localhost:11434/v1").unwrap(),
                 env_key: None,
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -120,7 +121,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "mistral",
             P {
                 name: "Mistral".into(),
-                base_url: "https://api.mistral.ai/v1".into(),
+                base_url: Url::parse("https://api.mistral.ai/v1").unwrap(),
                 env_key: Some("MISTRAL_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -130,7 +131,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "deepseek",
             P {
                 name: "DeepSeek".into(),
-                base_url: "https://api.deepseek.com".into(),
+                base_url: Url::parse("https://api.deepseek.com").unwrap(),
                 env_key: Some("DEEPSEEK_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -140,7 +141,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "xai",
             P {
                 name: "xAI".into(),
-                base_url: "https://api.x.ai/v1".into(),
+                base_url: Url::parse("https://api.x.ai/v1").unwrap(),
                 env_key: Some("XAI_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,
@@ -150,7 +151,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "groq",
             P {
                 name: "Groq".into(),
-                base_url: "https://api.groq.com/openai/v1".into(),
+                base_url: Url::parse("https://api.groq.com/openai/v1").unwrap(),
                 env_key: Some("GROQ_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,

--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -67,7 +67,7 @@ pub fn is_inside_git_repo(config: &Config) -> bool {
     false
 }
 
-pub (crate) trait UrlExt {
+pub trait UrlExt {
     /// Append a path to the URL, without modifying the original URL components.
     /// It allows us to configure query parameters and carry them over when we use
     /// different Wire API endpoints.
@@ -79,22 +79,37 @@ pub (crate) trait UrlExt {
 
 impl UrlExt for Url {
     fn append_path(self, path: &str) -> Result<Url, anyhow::Error> {
-        // Parse the path as a relative URL to get normalized path segments
-        let path_url = Url::parse(&format!("http://dummy{}", path))
-            .map_err(|e| anyhow::anyhow!("Invalid path: {}", e))?;
-        
         let mut url = self.clone();
+        
+        // Validate path doesn't contain invalid characters
+        if path.contains(|c: char| c.is_whitespace() || c == '?' || c == '#') {
+            return Err(anyhow::anyhow!("Invalid path: contains whitespace or special characters"));
+        }
+
+        // Split the path into segments, filtering out empty ones
+        let segments: Vec<&str> = path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if segments.is_empty() {
+            return Ok(url);
+        }
+
+        // Get path segments and add new segments
         {
-            let mut segments = url.path_segments_mut()
+            let mut path_segments = url.path_segments_mut()
                 .map_err(|_| anyhow::anyhow!("Failed to get path segments"))?;
             
-            // Add each segment from the parsed path URL
-            for segment in path_url.path_segments()
-                .ok_or_else(|| anyhow::anyhow!("Failed to get path segments from input"))? {
-                segments.push(segment);
+            // Remove trailing empty segment if it exists
+            path_segments.pop_if_empty();
+            
+            // Add each non-empty segment
+            for segment in segments {
+                path_segments.push(segment);
             }
         }
-        
+
         Ok(url)
     }
 }

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -100,7 +100,7 @@ async fn keeps_previous_response_id_between_tasks() {
     }
     let model_provider = ModelProviderInfo {
         name: "openai".into(),
-        base_url: format!("{}/v1", server.uri()),
+        base_url: url::Url::parse(&format!("{}/v1", server.uri())).unwrap(),
         // Environment variable that should exist in the test environment.
         // ModelClient will return an error if the environment variable for the
         // provider is not set.

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -88,7 +88,7 @@ async fn retries_on_early_close() {
 
     let model_provider = ModelProviderInfo {
         name: "openai".into(),
-        base_url: format!("{}/v1", server.uri()),
+        base_url: url::Url::parse(&format!("{}/v1", server.uri())).unwrap(),
         // Environment variable that should exist in the test environment.
         // ModelClient will return an error if the environment variable for the
         // provider is not set.

--- a/codex-rs/core/tests/test_url_ext.rs
+++ b/codex-rs/core/tests/test_url_ext.rs
@@ -1,0 +1,63 @@
+use url::Url;
+use codex_core::util::UrlExt;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_append_path_basic() {
+        let base_url = Url::parse("https://api.example.com/v1").unwrap();
+        let result = base_url.append_path("/models").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models");
+    }
+
+    #[test]
+    fn test_append_path_with_query_params() {
+        let base_url = Url::parse("https://api.example.com/v1?version=2023").unwrap();
+        let result = base_url.append_path("/models").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models?version=2023");
+    }
+
+    #[test]
+    fn test_append_path_with_multiple_segments() {
+        let base_url = Url::parse("https://api.example.com").unwrap();
+        let result = base_url.append_path("/v1/models/gpt-4").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models/gpt-4");
+    }
+
+    #[test]
+    fn test_append_path_with_existing_path() {
+        let base_url = Url::parse("https://api.example.com/v1").unwrap();
+        let result = base_url.append_path("/models/gpt-4").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models/gpt-4");
+    }
+
+    #[test]
+    fn test_append_path_with_trailing_slash() {
+        let base_url = Url::parse("https://api.example.com/v1/").unwrap();
+        let result = base_url.append_path("models").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models");
+    }
+
+    #[test]
+    fn test_append_path_with_complex_query() {
+        let base_url = Url::parse("https://api.example.com/v1?version=2023&api-key=123").unwrap();
+        let result = base_url.append_path("/models/gpt-4").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models/gpt-4?version=2023&api-key=123");
+    }
+
+    #[test]
+    fn test_append_path_with_fragment() {
+        let base_url = Url::parse("https://api.example.com/v1#section").unwrap();
+        let result = base_url.append_path("/models").unwrap();
+        assert_eq!(result.as_str(), "https://api.example.com/v1/models#section");
+    }
+
+    #[test]
+    fn test_append_path_with_invalid_path() {
+        let base_url = Url::parse("https://api.example.com").unwrap();
+        let result = base_url.append_path("invalid path with spaces");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
As far as I know only Azure / OpenAI supports reasoning API right now. This expands the chat completion streaming capabilities so we can use it more holistically with other providers, and still get a good experience.

I haven't tested this with MCP at all, but it does work with `bash` & `apply_patch`.

-------

@bolinfest please let us know if this is interesting upstream - or if you're already working on a better version. May make sense to clean up and make generally available.

